### PR TITLE
Support for #EXT-X-SESSION-DATA tag in master playlist

### DIFF
--- a/tests/unit/loader/playlist-loader.js
+++ b/tests/unit/loader/playlist-loader.js
@@ -128,6 +128,35 @@ http://proxy-21.dailymotion.com/sec(2a991e17f08fcd94f95637a6dd718ddd)/video/107/
     assert.strictEqual(result[9]['bitrate'], 6221600);
   });
 
+  it('parses manifest with EXT-X-SESSION-DATA', () => {
+    let manifest = `#EXTM3U
+#EXT-X-SESSION-DATA:DATA-ID="com.dailymotion.sessiondata.test",VALUE="some data"
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=836280,CODECS="mp4a.40.2,avc1.64001f",RESOLUTION=848x360,NAME="480"
+http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core`;
+
+    let result = M3U8Parser.parseMasterPlaylist(manifest, 'http://www.dailymotion.com');
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].sessionData['com.dailymotion.sessiondata.test'].length, 1);
+    assert.strictEqual(result[0].sessionData['com.dailymotion.sessiondata.test'][0].VALUE, 'some data');
+  });
+
+  it('parses manifest with multiply EXT-X-SESSION-DATA', () => {
+    let manifest = `#EXTM3U
+#EXT-X-SESSION-DATA:DATA-ID="com.dailymotion.sessiondata.test",VALUE="some data"
+#EXT-X-SESSION-DATA:DATA-ID="com.dailymotion.sessiondata.test",VALUE="another some data"
+#EXT-X-SESSION-DATA:DATA-ID="com.dailymotion.sessiondata.test2",VALUE="different data"
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=836280,CODECS="mp4a.40.2,avc1.64001f",RESOLUTION=848x360,NAME="480"
+http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core`;
+
+    let result = M3U8Parser.parseMasterPlaylist(manifest, 'http://www.dailymotion.com');
+    assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].sessionData['com.dailymotion.sessiondata.test'].length, 2);
+    assert.strictEqual(result[0].sessionData['com.dailymotion.sessiondata.test'][0].VALUE, 'some data');
+    assert.strictEqual(result[0].sessionData['com.dailymotion.sessiondata.test'][1].VALUE, 'another some data');
+    assert.strictEqual(result[0].sessionData['com.dailymotion.sessiondata.test2'].length, 1);
+    assert.strictEqual(result[0].sessionData['com.dailymotion.sessiondata.test2'][0].VALUE, 'different data');
+  });
+
   it('parses empty levels returns empty fragment array', () => {
     let level = '';
     let result = M3U8Parser.parseLevelPlaylist(level, 'http://proxy-62.dailymotion.com/sec(3ae40f708f79ca9471f52b86da76a3a8)/video/107/282/158282701_mp4_h264_aac_hq.m3u8#cell=core', 0);


### PR DESCRIPTION
### This PR will add parsing for tag EXT-X-SESSION-DATA in master playlist.

### Why is this Pull Request needed?

There is extra tag in specification (https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-02#section-4.4.4.4) allows to deliver additional data to player. 
It would be usefull in several cases, for example, to mark some levels with special names on a backend side.

### Are there any points in the code the reviewer needs to double check?

No.

### Resolves issues:

-

### Checklist

- [x] changes have been done against master branch, and PR does not conflict
- [x] no commits have been done in dist folder (we will take care of updating it)
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] API or design changes are documented in API.md
